### PR TITLE
feat: implement an chaos experiment with pumba

### DIFF
--- a/alts/chaos-toolkit-with-pumba/.gitignore
+++ b/alts/chaos-toolkit-with-pumba/.gitignore
@@ -1,0 +1,3 @@
+.venv
+chaostoolkit.log
+journal.json

--- a/alts/chaos-toolkit-with-pumba/README.md
+++ b/alts/chaos-toolkit-with-pumba/README.md
@@ -1,0 +1,20 @@
+# Chaos Toolkit with Pumba
+
+## Run
+
+```sh
+docker compose up -d
+# Wait for daemons to be ready
+./bin/chaos run experiments/delay.json
+docker compose down
+```
+
+## Components
+
+- [Chaos Toolkit](https://chaostoolkit.org/)
+- [Pumba](https://github.com/alexei-led/pumba)
+
+## Reading
+
+- [How to run Pumba in Kubernetes under control of the Chaos Toolkit
+](https://github.com/chaosiq/chaosiq/blob/4fa5e15e1f5fed1daec325a1bda3000fa4410c0c/pumba-kubernetes-integration/pumba-kubernetes.md)

--- a/alts/chaos-toolkit-with-pumba/bin/chaos
+++ b/alts/chaos-toolkit-with-pumba/bin/chaos
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+python3 -m venv .venv && source .venv/bin/activate && python3 -m pip install --upgrade pip
+pip3 install chaostoolkit
+.venv/bin/chaos "$@"

--- a/alts/chaos-toolkit-with-pumba/bin/pumba
+++ b/alts/chaos-toolkit-with-pumba/bin/pumba
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker run -v /var/run/docker.sock:/var/run/docker.sock -l com.gaiaadm.pumba=true gaiaadm/pumba:0.9.7 "$@"

--- a/alts/chaos-toolkit-with-pumba/bin/verify-connectivity-between-peers.sh
+++ b/alts/chaos-toolkit-with-pumba/bin/verify-connectivity-between-peers.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+docker_ids="$(docker ps -f "name=$1" --format '{{.ID}}')"
+ipfs_ids=""
+while read -r docker_id; do
+  ipfs_id="$(docker exec "$docker_id" ipfs id -f '<id>')"
+  while read -r other_docker_id; do
+    if [ "$docker_id" = "$other_docker_id" ]; then
+      continue
+    fi
+    ipfs_ids="$(docker exec "$other_docker_id" ipfs swarm peers)"
+    if ! echo "$ipfs_ids" | grep -q "$ipfs_id"; then
+      echo "Expected $ipfs_id to be connected to $other_docker_id" >&2
+      exit 1
+    fi
+  done <<< "$docker_ids"
+done <<< "$docker_ids"

--- a/alts/chaos-toolkit-with-pumba/bin/verify-running-container-count.sh
+++ b/alts/chaos-toolkit-with-pumba/bin/verify-running-container-count.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+count="$(docker ps -f "name=$1" --format '{{.ID}}' | wc -l)"
+if [ "$count" -ne $2 ]; then
+  echo "Expected $2 container(s), got $count" >&2
+  exit 1
+fi

--- a/alts/chaos-toolkit-with-pumba/docker-compose.yml
+++ b/alts/chaos-toolkit-with-pumba/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  ipfs:
+    image: ipfs/kubo:v0.17.0
+    deploy:
+      replicas: 2
+    networks:
+      - data
+
+networks:
+  data:
+    driver: bridge

--- a/alts/chaos-toolkit-with-pumba/experiments/delay.json
+++ b/alts/chaos-toolkit-with-pumba/experiments/delay.json
@@ -1,0 +1,46 @@
+{
+  "title": "Does increasing network delay disconnect Kubo peers?",
+  "description": "Increased delay shouldn't affect connection between Kubo peers.",
+  "configuration": {
+    "pwd": {
+      "type": "env",
+      "key": "PWD"
+    }
+  },
+  "steady-state-hypothesis": {
+    "title": "Kubo peers are connected to each other",
+    "probes": [
+      {
+        "type": "probe",
+        "name": "kubo-must-be-running",
+        "tolerance": 0,
+        "provider": {
+          "type": "process",
+          "path": "bash",
+          "arguments": "${pwd}/bin/verify-running-container-count.sh chaos-toolkit-with-pumba-ipfs- 2"
+        }
+      },
+      {
+        "type": "probe",
+        "name": "kubo-nodes-must-be-connected",
+        "tolerance": 0,
+        "provider": {
+          "type": "process",
+          "path": "bash",
+          "arguments": "${pwd}/bin/verify-connectivity-between-peers.sh"
+        }
+      }
+    ]
+  },
+  "method": [
+    {
+      "type": "action",
+      "name": "add-delay",
+      "provider": {
+        "type": "process",
+        "path": "bash",
+        "arguments": "${pwd}/bin/pumba netem --tc-image gaiadocker/iproute2 --duration 1m delay --time 1000 chaos-toolkit-with-pumba-ipfs-"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Chaos Toolkit with Pumba

## Run

```sh
docker compose up -d
# Wait for daemons to be ready
./bin/chaos run experiments/delay.json
docker compose down
```

## Components

- [Chaos Toolkit](https://chaostoolkit.org/)
- [Pumba](https://github.com/alexei-led/pumba)

## Reading

- [How to run Pumba in Kubernetes under control of the Chaos Toolkit
](https://github.com/chaosiq/chaosiq/blob/4fa5e15e1f5fed1daec325a1bda3000fa4410c0c/pumba-kubernetes-integration/pumba-kubernetes.md)